### PR TITLE
Replace --link with user-defined network

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ docker network create --driver bridge timebase-network
 docker network ls
 
 # run the timebase server container
-docker run --rm -d \ 
+docker run --rm -d \
    --name timebase-server \
-   --network timebase-network
-   -p 8011:8011 \ 
-   --ulimit nofile=65536:65536 \ 
+   --network timebase-network \
+   -p 8011:8011 \
+   --ulimit nofile=65536:65536 \
    finos/timebase-ce-server:6.1
 ```
 2. Run Docker container with [TimeBase WS Server](https://hub.docker.com/r/epam/timebase-ws-server)
 
 ```bash
 # run the timebase web admin container
-docker run --rm -d \ 
+docker run --rm -d \
    --name timebase-admin \
-   --network timebase-network
-   -p 8099:8099 \ 
+   --network timebase-network \
+   -p 8099:8099 \
    -e "JAVA_OPTS=-Dtimebase.url=dxtick://timebase-server:8011" \
    --ulimit nofile=65536:65536 \
-   epam/timebase-ws-server:0.5
+   epam/timebase-ws-server:1.0
 ```
 or start server from command line
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ docker run --rm -d \
    --name timebase-admin \
    --network timebase-network
    -p 8099:8099 \ 
-   -e "JAVA_OPTS=-Dtimebase.url=dxtick://timebase:8011" \
-    --ulimit nofile=65536:65536 \
+   -e "JAVA_OPTS=-Dtimebase.url=dxtick://timebase-server:8011" \
+   --ulimit nofile=65536:65536 \
    epam/timebase-ws-server:0.5
 ```
 or start server from command line

--- a/README.md
+++ b/README.md
@@ -35,18 +35,27 @@ TimeBase Administrator also serves as a **REST/WS gateway for TimeBase Server**.
 
 1. [Start TimeBase Server](https://kb.timebase.info/community/overview/quick-start)
 ```bash
+# create a user-defined network
+docker network create --driver bridge timebase-network
+
+# make sure the network was created
+docker network ls
+
+# run the timebase server container
 docker run --rm -d \ 
+   --name timebase-server \
+   --network timebase-network
    -p 8011:8011 \ 
-   --name=timebase-server \ 
    --ulimit nofile=65536:65536 \ 
    finos/timebase-ce-server:6.1
 ```
 2. Run Docker container with [TimeBase WS Server](https://hub.docker.com/r/epam/timebase-ws-server)
 
 ```bash
+# run the timebase web admin container
 docker run --rm -d \ 
    --name timebase-admin \
-    --link timebase-server:timebase \ 
+   --network timebase-network
    -p 8099:8099 \ 
    -e "JAVA_OPTS=-Dtimebase.url=dxtick://timebase:8011" \
     --ulimit nofile=65536:65536 \


### PR DESCRIPTION
The Docker documentation on [network links](https://docs.docker.com/network/links/) has the warning below. Note the comment about not being able to share environment variables with user-defined networks. I don't think that's an issue here though.

> The `--link` flag is a legacy feature of Docker. It may eventually be removed. Unless you absolutely need to continue using it, we recommend that you use user-defined networks to facilitate communication between two containers instead of using `--link`. One feature that user-defined networks do not support that you can do with `--link` is sharing environment variables between containers. However, you can use other mechanisms such as volumes to share environment variables between containers in a more controlled way.

This PR makes the recommended changes above. I've tested this locally without obvious issues.